### PR TITLE
Fix regular expression to detect unix sockets

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 #   - plaintext http is only allowed to localhost (to avoid leaking credentials on the network)
 #   - http(s) destination is webroot, no additional component allowed (eg. http://localhost:1234/test is invalid)
 rp_validate_proxy_path() {
-    if [[ ! $proxy_path =~ '^unix:/' ]]; then
+    if [[ ! $proxy_path =~ ^'unix:/' ]]; then
         url_regex='^(http://(127\.[0-9]+\.[0-9]+\.[0-9]+|localhost)|https://.*)(:[0-9]+)?(/.*)?$'
         [[ ! $proxy_path =~ $url_regex ]] && ynh_die \
         "For secure reason, you can't use an unencrypted http remote destination couple with ssowat for your reverse proxy: $proxy_path" 1


### PR DESCRIPTION
Fixes #3 

## Problem

- The `^` character was quoted causing it to be matched literally.

## Solution

- bring `^` out of the quotes

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
